### PR TITLE
fix: HashHistory Link hrefs escape the hash router

### DIFF
--- a/packages/router/src/react/components.tsx
+++ b/packages/router/src/react/components.tsx
@@ -178,7 +178,7 @@ export const Link = <P extends Pattern>(props: LinkProps<P>): ReactNode => {
   const anchorProps = {
     ...rest,
     ref: mergeRefs(ref, rest.ref),
-    href: url,
+    href: router.history.createHref?.(url) ?? url,
     onClick,
     onFocus: intentEvent(schedulePreload, rest.onFocus),
     onBlur: intentEvent(cancelPreload, rest.onBlur),

--- a/packages/router/src/router/browser-history.ts
+++ b/packages/router/src/router/browser-history.ts
@@ -38,6 +38,8 @@ export class BrowserHistory implements HistoryLike {
     history[replace ? replaceStateEvent : pushStateEvent](state, "", url);
   };
 
+  createHref = (url: string) => url;
+
   subscribe = (listener: () => void) => {
     events.forEach(event => addEventListener(event, listener));
     return () => {

--- a/packages/router/src/router/hash-history.ts
+++ b/packages/router/src/router/hash-history.ts
@@ -11,4 +11,6 @@ export class HashHistory extends BrowserHistory {
     const { url, replace, state } = options;
     history[replace ? "replaceState" : "pushState"](state, "", `#${url}`);
   };
+
+  createHref = (url: string) => `#${url}`;
 }

--- a/packages/router/src/router/memory-history.ts
+++ b/packages/router/src/router/memory-history.ts
@@ -36,6 +36,8 @@ export class MemoryHistory implements HistoryLike {
     this.listeners.forEach(listener => listener());
   };
 
+  createHref = (url: string) => url;
+
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
     return () => {

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -122,6 +122,7 @@ export interface HistoryLike {
   location: () => HistoryLocation;
   go: (delta: number) => void;
   push: (options: HistoryPushOptions) => void;
+  createHref?: (url: string) => string;
   subscribe: (listener: () => void) => () => void;
 }
 


### PR DESCRIPTION
## Problem

With `HashHistory`, `<Link>` renders an anchor whose `href` is the plain route-space path (e.g. `/posts/123`) instead of the hash form (`#/posts/123`).

Plain left-clicks still work because `Link`'s `onClick` intercepts them and routes through `router.navigate`, which goes through `HashHistory.push` (the only place that prepends `#`). But native browser link actions — Ctrl/Cmd-click, middle-click, "copy link address", "open in new tab" — use the `href` directly and bypass the click handler. On a static host (e.g. GitHub/GitLab Pages) the browser then requests `/posts/123` from the server, which doesn't exist, so the link is broken.

The root cause is that the mapping from an internal URL to a real browser URL lives only inside each history's `push`. `Link` has no read-only way to ask the history "what href should this URL render as", so it falls back to the raw path.

## Fix

Add an optional `createHref(url)` to `HistoryLike`:

- `BrowserHistory` / `MemoryHistory`: identity (`url => url`)
- ```HashHistory`: `url => `#${url}` ```

`Link` now sets `href: router.history.createHref?.(url) ?? url`.

- Navigation is unchanged — `navigate` still pushes the plain `url`, and `HashHistory.push` still adds the single `#`, so there is no double-`#`.
- `createHref` is optional on the interface, so existing custom `HistoryLike` implementations keep working (they fall back to identity).
- `BrowserHistory`/`MemoryHistory` hrefs are byte-for-byte unchanged.

## Verification

Rendering a real `<Link to="/posts/123">` through a real `HashHistory` router with `react-dom/server`:

Before: `<a href="/posts/123">`
After:  `<a href="#/posts/123">`

`BrowserHistory.createHref('/posts/123')` → `/posts/123` (unchanged), `HashHistory.createHref('/posts/123')` → `#/posts/123`.
